### PR TITLE
Fix tree sitter compat issue

### DIFF
--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -25,6 +25,8 @@ from aider.waiting import Spinner
 warnings.simplefilter("ignore", category=FutureWarning)
 from grep_ast.tsl import USING_TSL_PACK, get_language, get_parser  # noqa: E402
 
+from tree_sitter import QueryCursor
+
 Tag = namedtuple("Tag", "rel_fname fname line name kind".split())
 
 
@@ -286,7 +288,8 @@ class RepoMap:
 
         # Run the tags queries
         query = language.query(query_scm)
-        captures = query.captures(tree.root_node)
+        cursor = QueryCursor()
+        captures = cursor.captures(tree.root_node)
 
         saw = set()
         if USING_TSL_PACK:

--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -20,12 +20,12 @@ from tqdm import tqdm
 from aider.dump import dump
 from aider.special import filter_important_files
 from aider.waiting import Spinner
+from tree_sitter import QueryCursor
 
 # tree_sitter is throwing a FutureWarning
 warnings.simplefilter("ignore", category=FutureWarning)
 from grep_ast.tsl import USING_TSL_PACK, get_language, get_parser  # noqa: E402
 
-from tree_sitter import QueryCursor
 
 Tag = namedtuple("Tag", "rel_fname fname line name kind".split())
 


### PR DESCRIPTION
this fixes the issue with `tree-sitter=2.25.2` experiences in all aider installs this week